### PR TITLE
Adding text fallback for browsers without canvas (eg. IE8)

### DIFF
--- a/component.json
+++ b/component.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "component/autoscale-canvas": "*",
     "component/raf": "*",
-    "component-has/canvas": "*"
+    "component-has/canvas": "*",
+    "matthewp/text": "*"
   },
   "license": "MIT",
   "repo": "component/spinner"

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var autoscale = require('autoscale-canvas');
 var raf = require('raf');
+var text = require('text');
 var supported = require('canvas');
 
 /**
@@ -80,7 +81,7 @@ Spinner.prototype.size = function(n){
 
 Spinner.prototype.text = function(str){
   this._text = str;
-  if (!supported) this.el.innerText = str;
+  if (!supported) text(this.el, str);
   return this;
 };
 


### PR DESCRIPTION
This PR allows for browsers that do not support `<canvas>` (_cough_ IE8 _cough_) to work. I did not attempt to polyfill canvas or anything like that. Instead, if the browser does not support canvas, a `<div>` is created in place of the `<canvas>` and it's `innerText` is updated when the `Spinner#text()` method is called.

I'll leave this open for a few days for review.
